### PR TITLE
Updates to Python sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+[.][v]env/
+*.py[co]
+__pycache__

--- a/samples/python-markdown/complete_job_with_delay_handler.py
+++ b/samples/python-markdown/complete_job_with_delay_handler.py
@@ -50,7 +50,7 @@ class CompleteJobWithDelayHandler(BaseMiddleware):
                 # not a job URL we should follow
                 return response
           
-            logger.info(f"Waiting {self.delayMs}ms before following location {location}...")
+            logger.info("Waiting %sms before following location %s...", self.delayMs, location)
             time.sleep(self.delayMs / 1000)
             
             new_request = self._create_new_request("GET", location, request_before)

--- a/samples/python-markdown/connection_service.py
+++ b/samples/python-markdown/connection_service.py
@@ -1,12 +1,17 @@
 import json
+import logging
+
 from msgraph.generated.models.json import Json
 from connection_configuration import external_connection, schema
 from graph_service import graph_client
 
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
 
 async def _create_connection():
-    print("Creating connection...", end="")
-    with open("resultLayout.json", "r") as file:
+    logger.info("Creating connection...")
+    with open("resultLayout.json", "r", encoding='utf-8') as file:
         adaptive_card = file.read()
         layout = json.loads(adaptive_card)
 
@@ -18,18 +23,18 @@ async def _create_connection():
         )
 
     await graph_client.external.connections.post(external_connection)
-    print("DONE")
+    logger.info("DONE")
 
 
 async def _create_schema():
-    print("Creating schema...")
+    logger.info("Creating schema...")
 
     assert external_connection.id is not None
     await graph_client.external.connections.by_external_connection_id(
         external_connection.id
     ).schema.patch(schema)
 
-    print("DONE")
+    logger.info("DONE")
 
 
 async def create_connection():

--- a/samples/python-markdown/connection_service.py
+++ b/samples/python-markdown/connection_service.py
@@ -3,30 +3,35 @@ from msgraph.generated.models.json import Json
 from connection_configuration import external_connection, schema
 from graph_service import graph_client
 
+
 async def _create_connection():
-  print("Creating connection...", end="")
-  with open('resultLayout.json', 'r') as file:
-    adaptive_card = file.read()
-    layout = json.loads(adaptive_card)
+    print("Creating connection...", end="")
+    with open("resultLayout.json", "r") as file:
+        adaptive_card = file.read()
+        layout = json.loads(adaptive_card)
 
-    assert external_connection.search_settings is not None
-    assert external_connection.search_settings.search_result_templates is not None
+        assert external_connection.search_settings is not None
+        assert external_connection.search_settings.search_result_templates is not None
 
-    external_connection.search_settings.search_result_templates[0].layout = Json(
-      additional_data=layout
-    )
+        external_connection.search_settings.search_result_templates[0].layout = Json(
+            additional_data=layout
+        )
 
-  await graph_client.external.connections.post(external_connection)
-  print("DONE")
+    await graph_client.external.connections.post(external_connection)
+    print("DONE")
+
 
 async def _create_schema():
-  print("Creating schema...")
+    print("Creating schema...")
 
-  assert external_connection.id is not None
-  await graph_client.external.connections.by_external_connection_id(external_connection.id).schema.patch(schema)
-  
-  print("DONE")
+    assert external_connection.id is not None
+    await graph_client.external.connections.by_external_connection_id(
+        external_connection.id
+    ).schema.patch(schema)
+
+    print("DONE")
+
 
 async def create_connection():
-  await _create_connection()
-  await _create_schema()
+    await _create_connection()
+    await _create_schema()

--- a/samples/python-markdown/content_service.py
+++ b/samples/python-markdown/content_service.py
@@ -62,7 +62,7 @@ def _extract():
         ):
             return
 
-        with open(file_path, "r") as file:
+        with open(file_path, "r", encoding='utf-8') as file:
             post = frontmatter.load(file)
             post.content = _markdown_to_text(post.content)
             post.url = urljoin(base_url, post.metadata["slug"])  # type: ignore
@@ -121,7 +121,7 @@ def _transform(content) -> Generator[ExternalItem, None, None]:
 async def _load(content: Generator[ExternalItem, None, None]):
     for doc in content:
         try:
-            logger.info(f"Loading {doc.id}...")
+            logger.info("Loading %s...", doc.id)
 
             assert external_connection.id is not None
             assert doc.id is not None
@@ -131,7 +131,7 @@ async def _load(content: Generator[ExternalItem, None, None]):
             ).items.by_external_item_id(doc.id).put(doc)
             logger.info("DONE loading")
         except Exception as e:
-            logger.error(f"Failed to load {doc.id}: {e}")
+            logger.error("Failed to load %s: %s", doc.id, e)
             return
 
 

--- a/samples/python-markdown/content_service.py
+++ b/samples/python-markdown/content_service.py
@@ -1,6 +1,7 @@
 import frontmatter
 import os
 import re
+import logging
 from bs4 import BeautifulSoup
 from datetime import datetime
 from markdown import markdown
@@ -28,6 +29,9 @@ from msgraph.generated.models.external_connectors.properties import Properties
 
 from connection_configuration import external_connection, user_id
 from graph_service import graph_client
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 def _markdown_to_text(markdown_string):
@@ -117,7 +121,7 @@ def _transform(content) -> Generator[ExternalItem, None, None]:
 async def _load(content: Generator[ExternalItem, None, None]):
     for doc in content:
         try:
-            print(f"Loading {doc.id}...", end="")
+            logger.info(f"Loading {doc.id}...")
 
             assert external_connection.id is not None
             assert doc.id is not None
@@ -125,9 +129,9 @@ async def _load(content: Generator[ExternalItem, None, None]):
             await graph_client.external.connections.by_external_connection_id(
                 external_connection.id
             ).items.by_external_item_id(doc.id).put(doc)
-            print("DONE")
+            logger.info("DONE loading")
         except Exception as e:
-            print(f"Failed to load {doc.id}: {e}")
+            logger.error(f"Failed to load {doc.id}: {e}")
             return
 
 

--- a/samples/python-markdown/content_service.py
+++ b/samples/python-markdown/content_service.py
@@ -9,11 +9,19 @@ from urllib.parse import urljoin
 from msgraph.generated.models.external_connectors.access_type import AccessType
 from msgraph.generated.models.external_connectors.acl import Acl
 from msgraph.generated.models.external_connectors.acl_type import AclType
-from msgraph.generated.models.external_connectors.external_activity import ExternalActivity
-from msgraph.generated.models.external_connectors.external_activity_type import ExternalActivityType
+from msgraph.generated.models.external_connectors.external_activity import (
+    ExternalActivity,
+)
+from msgraph.generated.models.external_connectors.external_activity_type import (
+    ExternalActivityType,
+)
 from msgraph.generated.models.external_connectors.external_item import ExternalItem
-from msgraph.generated.models.external_connectors.external_item_content import ExternalItemContent
-from msgraph.generated.models.external_connectors.external_item_content_type import ExternalItemContentType
+from msgraph.generated.models.external_connectors.external_item_content import (
+    ExternalItemContent,
+)
+from msgraph.generated.models.external_connectors.external_item_content_type import (
+    ExternalItemContentType,
+)
 from msgraph.generated.models.external_connectors.identity import Identity
 from msgraph.generated.models.external_connectors.identity_type import IdentityType
 from msgraph.generated.models.external_connectors.properties import Properties
@@ -21,102 +29,109 @@ from msgraph.generated.models.external_connectors.properties import Properties
 from connection_configuration import external_connection, user_id
 from graph_service import graph_client
 
+
 def _markdown_to_text(markdown_string):
-    """ Converts a markdown string to plaintext """
+    """Converts a markdown string to plaintext"""
 
     # md -> html -> text since BeautifulSoup can extract text cleanly
     html = markdown(markdown_string)
 
     # remove code snippets
-    html = re.sub(r'<pre>(.*?)</pre>', ' ', html)
-    html = re.sub(r'<code>(.*?)</code >', ' ', html)
+    html = re.sub(r"<pre>(.*?)</pre>", " ", html)
+    html = re.sub(r"<code>(.*?)</code >", " ", html)
 
     # extract text
     soup = BeautifulSoup(html, "html.parser")
-    text = ''.join(soup.findAll(text=True))
+    text = "".join(soup.findAll(text=True))
 
     return text
 
-def _extract():
-  base_url = "https://blog.mastykarz.nl"
-  folder_path = "content"
 
-  for filename in os.listdir(folder_path):
-    file_path = os.path.join(folder_path, filename)
-    if not os.path.isfile(file_path) and (filename.endswith(".markdown") or filename.endswith(".md")):
-        return
-    
-    with open(file_path, "r") as file:
-      post = frontmatter.load(file)
-      post.content = _markdown_to_text(post.content)
-      post.url = urljoin(base_url, post.metadata["slug"]) # type: ignore
-      post.image = urljoin(base_url, post.metadata["image"]) # type: ignore
-      yield post
+def _extract():
+    base_url = "https://blog.mastykarz.nl"
+    folder_path = "content"
+
+    for filename in os.listdir(folder_path):
+        file_path = os.path.join(folder_path, filename)
+        if not os.path.isfile(file_path) and (
+            filename.endswith(".markdown") or filename.endswith(".md")
+        ):
+            return
+
+        with open(file_path, "r") as file:
+            post = frontmatter.load(file)
+            post.content = _markdown_to_text(post.content)
+            post.url = urljoin(base_url, post.metadata["slug"])  # type: ignore
+            post.image = urljoin(base_url, post.metadata["image"])  # type: ignore
+            yield post
+
 
 def _transform(content) -> Generator[ExternalItem, None, None]:
-  # needed to properly format activity date
-  local_time_with_timezone = datetime.now().astimezone()
+    # needed to properly format activity date
+    local_time_with_timezone = datetime.now().astimezone()
 
-  for post in content:
-    # Date must be in the ISO 8601 format
-    if isinstance(post.metadata["date"], str):
-      post.metadata["date"] = datetime.strptime(post.metadata["date"], "%Y-%m-%d %H:%M:%S")
-    
-    date: str = post.metadata["date"].isoformat()
-    yield ExternalItem(
-      id=post.metadata["slug"],
-      properties=Properties(
-        additional_data={
-          "title": post.metadata["title"],
-          "excerpt": post.metadata["excerpt"],
-          "imageUrl": post.image,
-          "url": post.url,
-          "date": date,
-          "tags@odata.type": "Collection(String)",
-          "tags": post.metadata["tags"]
-        }
-      ),
-      content=ExternalItemContent(
-        type=ExternalItemContentType.Text,
-        value=post.content
-      ),
-      acl=[
-        Acl(
-          type=AclType.Everyone,
-          value="everyone",
-          access_type=AccessType.Grant
+    for post in content:
+        # Date must be in the ISO 8601 format
+        if isinstance(post.metadata["date"], str):
+            post.metadata["date"] = datetime.strptime(
+                post.metadata["date"], "%Y-%m-%d %H:%M:%S"
+            )
+
+        date: str = post.metadata["date"].isoformat()
+        yield ExternalItem(
+            id=post.metadata["slug"],
+            properties=Properties(
+                additional_data={
+                    "title": post.metadata["title"],
+                    "excerpt": post.metadata["excerpt"],
+                    "imageUrl": post.image,
+                    "url": post.url,
+                    "date": date,
+                    "tags@odata.type": "Collection(String)",
+                    "tags": post.metadata["tags"],
+                }
+            ),
+            content=ExternalItemContent(
+                type=ExternalItemContentType.Text, value=post.content
+            ),
+            acl=[
+                Acl(
+                    type=AclType.Everyone,
+                    value="everyone",
+                    access_type=AccessType.Grant,
+                )
+            ],
+            activities=[
+                ExternalActivity(
+                    odata_type="#microsoft.graph.externalConnectors.externalActivity",
+                    type=ExternalActivityType.Created,
+                    start_date_time=post.metadata["date"].replace(
+                        tzinfo=local_time_with_timezone.tzinfo
+                    ),
+                    performed_by=Identity(type=IdentityType.User, id=user_id),
+                )
+            ],
         )
-      ],
-      activities=[
-        ExternalActivity(
-          odata_type="#microsoft.graph.externalConnectors.externalActivity",
-          type=ExternalActivityType.Created,
-          start_date_time=post.metadata["date"].replace(tzinfo=local_time_with_timezone.tzinfo),
-          performed_by=Identity(
-            type=IdentityType.User,
-            id=user_id
-          )
-        )
-      ]
-    )
+
 
 async def _load(content: Generator[ExternalItem, None, None]):
-  for doc in content:
-    try:
-      print(f"Loading {doc.id}...", end="")
+    for doc in content:
+        try:
+            print(f"Loading {doc.id}...", end="")
 
-      assert external_connection.id is not None
-      assert doc.id is not None
-      
-      await graph_client.external.connections.by_external_connection_id(
-          external_connection.id
-        ).items.by_external_item_id(doc.id).put(doc)
-      print("DONE")
-    except Exception as e:
-      print(f"Failed to load {doc.id}: {e}")
-      return
+            assert external_connection.id is not None
+            assert doc.id is not None
+
+            await graph_client.external.connections.by_external_connection_id(
+                external_connection.id
+            ).items.by_external_item_id(doc.id).put(doc)
+            print("DONE")
+        except Exception as e:
+            print(f"Failed to load {doc.id}: {e}")
+            return
+
 
 async def load_content():
-  content = _extract()
-  transformed = _transform(content)
-  await _load(transformed)
+    content = _extract()
+    transformed = _transform(content)
+    await _load(transformed)

--- a/samples/python-markdown/debug_handler.py
+++ b/samples/python-markdown/debug_handler.py
@@ -2,8 +2,6 @@ from kiota_http.middleware import BaseMiddleware
 import httpx
 
 class DebugHandler(BaseMiddleware):
-    def __init__(self) -> None:
-        super().__init__()
 
     async def send(
         self, request: httpx.Request, transport: httpx.AsyncBaseTransport

--- a/samples/python-markdown/graph_service.py
+++ b/samples/python-markdown/graph_service.py
@@ -1,8 +1,13 @@
 import configparser
 from azure.identity import ClientSecretCredential
 from httpx import AsyncClient, Timeout
-from kiota_authentication_azure.azure_identity_authentication_provider import AzureIdentityAuthenticationProvider
-from kiota_http.kiota_client_factory import DEFAULT_CONNECTION_TIMEOUT, DEFAULT_REQUEST_TIMEOUT
+from kiota_authentication_azure.azure_identity_authentication_provider import (
+    AzureIdentityAuthenticationProvider,
+)
+from kiota_http.kiota_client_factory import (
+    DEFAULT_CONNECTION_TIMEOUT,
+    DEFAULT_REQUEST_TIMEOUT,
+)
 from msgraph import GraphServiceClient, GraphRequestAdapter
 from msgraph_core import GraphClientFactory
 
@@ -26,17 +31,20 @@ if args.with_proxy:
         "http://": "http://0.0.0.0:8000",
         "https://": "http://0.0.0.0:8000",
     }
-    http_client = AsyncClient(proxies=_proxies, verify=False, timeout=timeout, http2=True) # type: ignore
+    http_client = AsyncClient(proxies=_proxies, verify=False, timeout=timeout, http2=True)  # type: ignore
 else:
     http_client = AsyncClient(timeout=timeout, http2=True)
 
 _middleware = GraphClientFactory.get_default_middleware(None)
 # _middleware.append(DebugHandler())
 _middleware.insert(0, CompleteJobWithDelayHandler(60000))
-http_client = GraphClientFactory.create_with_custom_middleware(_middleware, client=http_client)
+http_client = GraphClientFactory.create_with_custom_middleware(
+    _middleware, client=http_client
+)
 _adapter = GraphRequestAdapter(_auth_provider, http_client)
 
-graph_client = GraphServiceClient(_credential,
-                                  scopes=[
-                                      "https://graph.microsoft.com/.default"],
-                                  request_adapter=_adapter)
+graph_client = GraphServiceClient(
+    _credential,
+    scopes=["https://graph.microsoft.com/.default"],
+    request_adapter=_adapter,
+)


### PR DESCRIPTION
- Use a logger instead of print statements. This is preferable so that it's configurable which messages are shown based on the logging level. I didn't touch the debug handler, I'm surprised there isn't one already in kiota-http. 
- Added the python cache files to gitignore
- Added virtual env folders to gitignore
- Formatted the files because some had 2 whitespace instead of 4
- Enforced encoding of utf-8 when reading files (not doing this will be a warning in future versions of Python)