### PR TITLE
refactor: update task definitions and environment setup for food catalog sample

### DIFF
--- a/samples/nodejs-typescript-food-catalog/.vscode/tasks.json
+++ b/samples/nodejs-typescript-food-catalog/.vscode/tasks.json
@@ -4,35 +4,32 @@
     {
       "label": "TTK",
       "dependsOn": [
-        "npm install",
         "Ensure env files",
         "Ensure DevTunnel",
-        "Start Azurite emulator",
         "Provision",
+        "Start Azurite emulator",
+        "Deploy"
       ],
       "dependsOrder": "sequence"
     },
     {
+      "label": "Ensure env files",
       "type": "shell",
-      "label": "npm install",
-      "command": "npm install --no-audit"
-    },
-    {
-      "type": "shell",
-      "label": "Run watch",
-      "command": "npm run watch",
-      "isBackground": true,
-      "problemMatcher": "$tsc-watch"
-    },
-    {
-      "type": "func",
-      "label": "func: host start",
-      "command": "host start",
-      "problemMatcher": "$func-node-watch",
-      "isBackground": true,
-      "dependsOn": [
-        "Run watch"
-      ]
+      "command": "node ./scripts/env.js",
+      "isBackground": false,
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": "^.*$",
+            "file": 0,
+            "location": 1,
+            "message": 2
+          }
+        ]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
     },
     {
       "label": "Ensure DevTunnel",
@@ -62,33 +59,20 @@
       "options": {
         "cwd": "${workspaceFolder}"
       },
-      "dependsOn":[
+      "dependsOn": [
         "Ensure env files"
       ]
     },
     {
-      "label": "Ensure env files",
-      "type": "shell",
-      "command": "node ./scripts/env.js",
-      "isBackground": true,
-      "problemMatcher": {
-        "pattern": [
-          {
-            "regexp": "^.*$",
-            "file": 0,
-            "location": 1,
-            "message": 2
-          }
-        ],
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": "Ensuring env files exist...",
-          "endsPattern": "Done!"
-        }
+      "label": "Provision",
+      "type": "teamsfx",
+      "command": "provision",
+      "args": {
+        "env": "local"
       },
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
+      "dependsOn": [
+        "Ensure DevTunnel"
+      ]
     },
     {
       "label": "Start Azurite emulator",
@@ -112,17 +96,37 @@
       },
       "options": {
         "cwd": "${workspaceFolder}"
-      }
+      },
+      "dependsOn": [
+        "Provision"
+      ]
     },
     {
-      "label": "Provision",
+      "label": "Deploy",
       "type": "teamsfx",
-      "command": "provision",
+      "command": "deploy",
       "args": {
         "env": "local"
       },
-      "dependsOn":[
-        "Ensure DevTunnel"
+      "dependsOn": [
+        "Start Azurite emulator"
+      ]
+    },
+    {
+      "type": "shell",
+      "label": "Run watch",
+      "command": "npm run watch",
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch"
+    },
+    {
+      "type": "func",
+      "label": "func: host start",
+      "command": "host start",
+      "problemMatcher": "$func-node-watch",
+      "isBackground": true,
+      "dependsOn": [
+        "Run watch"
       ]
     },
     {

--- a/samples/nodejs-typescript-food-catalog/appPackage/manifest.json
+++ b/samples/nodejs-typescript-food-catalog/appPackage/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "manifestVersion": "1.16",
   "id": "cda3f6a2-4b7e-4f9c-8c0a-3b5b7a9f1d0c",
   "packageName": "com.package.name",

--- a/samples/nodejs-typescript-food-catalog/scripts/env.js
+++ b/samples/nodejs-typescript-food-catalog/scripts/env.js
@@ -7,7 +7,7 @@ const envPath = path.join(__dirname, "..", "env");
 const envs = [
   {
     name: ".env.local",
-    content: `TEAMSFX_ENV=local\nAPP_NAME=Foodsie\nTUNNEL_ID=\nNOTIFICATION_ENDPOINT=\nNOTIFICATION_DOMAIN=`,
+    content: `TEAMSFX_ENV=local\nAPP_NAME=Foodsie\nTUNNEL_ID=\nNOTIFICATION_ENDPOINT=\nNOTIFICATION_DOMAIN=\n`,
   },
   {
     name: ".env.local.user",

--- a/samples/nodejs-typescript-food-catalog/teamsapp.local.yml
+++ b/samples/nodejs-typescript-food-catalog/teamsapp.local.yml
@@ -6,7 +6,16 @@ version: 1.0.0
 environmentFolderPath: ./env
 
 provision:
-  
+  - uses: devTool/install
+    with:
+      func:
+        version: ~4.0.6610
+
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit
+
+deploy:
   - uses: script
     name: Ensure tables and data
     with:


### PR DESCRIPTION
Merging this PR will update the `nodejs-typescript-food-catalog` sample:

- We now have two stages in the YAML file instead of one
	- Provision
		- Ensures Azure Functions Core Tools v4 are installed
		- Executes npm install
	- Deploy
		- Contains the original tasks
- Early exit if Dev Tunnels CLI is not installed
	- We ensure the env files, then run the Dev Tunnels script before anything else
	- If CLI is not installed, the whole process stops and a message is shown with a link to docs with install info in the terminal output
- After ensuring the Dev Tunnel
	- We run the tasks in the Provision stage in YAML file
	- We start the Azurite service
	- We run the tasks in the Deploy stage in YAML file
- Fixes issue where NOTIFICATION_DOMAIN env var was not being created
- Tasks are no longer executed if the previous task in the sequence fails