### PR TITLE
fix: correct cron expression and update Node.js to v20

### DIFF
--- a/samples/nodejs-typescript-policies/infra/azure.bicep
+++ b/samples/nodejs-typescript-policies/infra/azure.bicep
@@ -91,7 +91,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~18' // Set NodeJS version to 18.x
+          value: '~20' // Set NodeJS version to 20 as 18 is not supported any longer
         }
         {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'

--- a/samples/nodejs-typescript-policies/src/functions/connections.ts
+++ b/samples/nodejs-typescript-policies/src/functions/connections.ts
@@ -45,9 +45,10 @@ export async function retractConnection(timer: Timer, context: InvocationContext
 }
 
 const currentDate = new Date();
-const cronExpression = `0 0 0 ${currentDate.getUTCMonth()} ${currentDate.getUTCDay()} *`;
+// Azure Functions cron format: {second} {minute} {hour} {day} {month} {day-of-week}
+const cronExpression = `0 0 0 ${currentDate.getUTCDate()} ${currentDate.getUTCMonth() + 1} *`;
 app.timer('deployConnection', {
-  // Runs every year
+  // Runs every year on the same date
   schedule: cronExpression,	
   runOnStartup: process.env.AZURE_FUNCTIONS_ENVIRONMENT === 'Development',
   handler: deployConnection


### PR DESCRIPTION
## Summary

This PR fixes two issues in the nodejs-typescript-policies sample:
### 1. Fix cron expression bug in connections.ts

**Before:**
```typescript
const cronExpression = `0 0 0 ${currentDate.getUTCMonth()} ${currentDate.getUTCDay()} *`;
// Result: '0 0 0 0 4 *' - Invalid! Day cannot be 0
```

**After:**
```typescript
const cronExpression = `0 0 0 ${currentDate.getUTCDate()} ${currentDate.getUTCMonth() + 1} *`;
// Result: '0 0 0 15 1 *' - Valid cron expression
```

The issue was:
- `getUTCMonth()` returns 0-11, was incorrectly placed in the day position
- `getUTCDay()` returns day of week (0-6), was incorrectly placed in the month position
- Correct format: `{second} {minute} {hour} {day} {month} {day-of-week}`

### 2. Update Node.js version in azure.bicep

Updated `WEBSITE_NODE_DEFAULT_VERSION` from `~18` to `~20` since Node.js 18 is no longer supported.

## Testing

- Tested locally with F5 debug, Azure Function starts successfully without cron expression errors."